### PR TITLE
Match control style to other DevTools tabs

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -92,6 +92,21 @@ div.log-item.input::before {
 #snippets {
   display: inline-block;
 }
+button,
+select {
+  background-image: linear-gradient(hsl(0, 0%, 93%), hsl(0, 0%, 93%) 38%, hsl(0, 0%, 87%));
+  border: 1px solid hsla(0, 0%, 0%, 0.25);
+  border-radius: 2px;
+  box-shadow: 0 1px 0 hsla(0, 0%, 0%, 0.08), inset 0 1px 2px hsla(0, 100%, 100%, 0.75);
+  color: hsl(0, 0%, 27%);
+  font-size: 12px;
+  margin: 0 1px 0 0;
+  text-shadow: 0 1px 0 hsl(0, 0%, 94%);
+  min-height: 2em !important;
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-user-select: none;
+}
   </style>
   <script src="ace/src/ace.js" charset="utf-8"></script>
   <script src="prettyprint.min.js"></script>


### PR DESCRIPTION
This one is minor. I just copied the style from one of the "official" buttons on the Profiles tab. Just to keep the look and feel a little more consistent :smile: 

![image](https://cloud.githubusercontent.com/assets/1479206/10821016/8e77f366-7e26-11e5-9a61-eac89dca5864.png)
